### PR TITLE
Install script support for UTF-8 encoding and line endings as LF

### DIFF
--- a/Install-ConEmuTheme.ps1
+++ b/Install-ConEmuTheme.ps1
@@ -20,8 +20,11 @@ param (
 )
 
 try {
-    [Xml]$config = Get-Content -Path $ConfigPath
-    $config.Save([System.IO.Path]::ChangeExtension($ConfigPath, ".backup.xml"))
+    [Xml]$config = Get-Content -Path $ConfigPath -Encoding UTF8
+    $fw = New-Object System.IO.StreamWriter([System.IO.Path]::ChangeExtension($ConfigPath, ".backup.xml"))
+    $fw.NewLine = "`n"
+    $config.Save($fw)
+    $fw.Close()
 
     $vanilla = $config.key.key.key | Where-Object { $_.name -eq ".Vanilla" }
     $colors = $vanilla.key | Where-Object { $_.name -eq "Colors" }
@@ -72,7 +75,10 @@ try {
         $colors.key.name = "Palette1"
     }
 
-    $config.Save($ConfigPath)
+    $fw = New-Object System.IO.StreamWriter($ConfigPath)
+    $fw.NewLine = "`n"
+    $config.Save($fw)
+    $fw.Close()
 } catch {
     Write-Error -Message $_
 }


### PR DESCRIPTION
Two changes to the install script:

1. Add support for reading the ConEmu config file as UTF-8 encoding. Otherwise the script would throw an error **when meetting non-ASCII characters**.
2. Write the updated config file and the backup config file with the line endings as LF and the encoding as UTF-8 (no BOM).

I have tested it on my two computers - Windows 7 64-bit and Windows 10 64-bit.

I'm looking forward to your response. Thanks.

