### PR TITLE
Move to tinted-terminal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tinted-theming/conemu
+* @tinted-theming/conemu-terminal

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,8 +1,6 @@
 name: Update with the latest tinted-theming colorschemes
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 0" # https://crontab.guru/every-week
 
 jobs:
   build-and-commit:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Tinted ConEmu
 
+**Deprecated**: tinted-conemu and all the other Tinted Theming
+terminal template repositories have moved to a single [Tinted
+Terminal](https://github.com/tinted-theming/tinted-terminal) repository.
+
+---
+
 Formerly [base16-conemu], however since the repository now supports the
 [base16] and [base24] scheme systems, the repo has been renamed.
 


### PR DESCRIPTION
As discussed in https://github.com/tinted-theming/home/issues/44#issuecomment-2518520414, this PR adds a deprecation notice and links to [tinted-terminal](https://github.com/tinted-theming/tinted-terminal). @tinted-theming/conemu-terminal  should already have maintainer access for [tinted-terminal](https://github.com/tinted-theming/tinted-terminal).

- Add deprecation notice to README
- Remove cron job